### PR TITLE
Fix union typeinfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "rtti",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rtti",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Runtime type validation for JavaScript and TypeScript programs",
     "main": "dist/commonjs/index.js",
     "typings": "dist/commonjs/index.d.ts",

--- a/src/create-type-info.ts
+++ b/src/create-type-info.ts
@@ -70,8 +70,7 @@ type TypeOfIntersection<Members> = Anonymize<
     Members[any] extends infer E ? (E extends TypeInfo<infer T> ? (x: T) => 0 : 0) extends ((x: infer I) => 0) ? I : 0 : 0
 >;
 
-type TypeOfUnion<Members>
-    = Anonymize<Members[any] extends infer E ? (E extends TypeInfo<infer T> ? T : 0) : 0>;
+type TypeOfUnion<Members> = Members[any] extends infer E ? (E extends TypeInfo<infer T> ? T : 0) : 0;
 
 type TypeOfObject<Props> = Anonymize<
     & {[K in RequiredPropNames<Props>]: Props[K] extends TypeInfo<infer T> ? T : 0}

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,33 @@
+// Type tests: the code here is not executed, it just needs to pass type checks to be considered successful.
+// Note that `t` is imported from the built declaration files, since that's where a regression occurred.
+
+import {t} from '../dist/commonjs';
+export {test1, test2};
+
+// Intersection
+const T1 = t.intersection(
+    t.object({foo: t.string, bar: t.number}),
+    t.object({bar: t.unknown, baz: t.number}),
+    t.object({quux: t.array(t.string)}),
+);
+function test1(t1: typeof T1.example) {
+    t1.foo.padStart;
+    t1.bar.toFixed;
+    t1.baz.toFixed;
+    t1.quux.map(el => el.padStart);
+}
+
+// Union
+const T2 = t.union(
+    t.object({kind: t.unit('A'), foo: t.number}),
+    t.object({kind: t.unit('B'), bar: t.boolean}),
+    t.object({kind: t.unit('C'), baz: t.string}),
+);
+function test2(t2: typeof T2.example) {
+    switch (t2.kind) {
+        case 'A': t2.foo.toFixed; break;
+        case 'B': t2.bar; break;
+        case 'C': t2.baz.padStart; break;
+        default: ((x: never) => x)(t2);
+    }
+}


### PR DESCRIPTION
There was a regression in the union type builder. This PR fixes it and adds a test file for the regression.
