### PR TITLE
Remove all external deps from runtime code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "rtti",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "rtti",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,8 @@
             "name": "rtti",
             "version": "1.1.1",
             "license": "MIT",
-            "dependencies": {
-                "lodash.clonedeep": "^4.5.0"
-            },
             "devDependencies": {
                 "@types/chai": "^4.3.0",
-                "@types/lodash.clonedeep": "^4.5.6",
                 "@types/mocha": "^9.1.0",
                 "@types/node": "^16.*",
                 "chai": "^4.3.6",
@@ -74,21 +70,6 @@
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
             "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
             "dev": true
-        },
-        "node_modules/@types/lodash": {
-            "version": "4.14.178",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-            "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
-            "dev": true
-        },
-        "node_modules/@types/lodash.clonedeep": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-            "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
         },
         "node_modules/@types/mocha": {
             "version": "9.1.0",
@@ -745,11 +726,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-        },
         "node_modules/log-symbols": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -794,9 +770,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-            "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+            "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
             "dev": true,
             "dependencies": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -1350,21 +1326,6 @@
             "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
             "dev": true
         },
-        "@types/lodash": {
-            "version": "4.14.178",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-            "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
-            "dev": true
-        },
-        "@types/lodash.clonedeep": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-            "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-            "dev": true,
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
         "@types/mocha": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
@@ -1842,11 +1803,6 @@
                 "p-locate": "^5.0.0"
             }
         },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-        },
         "log-symbols": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -1882,9 +1838,9 @@
             }
         },
         "mocha": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-            "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+            "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rtti",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Runtime type validation for JavaScript and TypeScript programs",
     "main": "dist/commonjs/index.js",
     "typings": "dist/commonjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,8 @@
     "bugs": {
         "url": "https://github.com/yortus/rtti/issues"
     },
-    "dependencies": {
-        "lodash.clonedeep": "^4.5.0"
-    },
     "devDependencies": {
         "@types/chai": "^4.3.0",
-        "@types/lodash.clonedeep": "^4.5.6",
         "@types/mocha": "^9.1.0",
         "@types/node": "^16.*",
         "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rtti",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Runtime type validation for JavaScript and TypeScript programs",
     "main": "dist/commonjs/index.js",
     "typings": "dist/commonjs/index.d.ts",

--- a/src/operations/assert-valid.ts
+++ b/src/operations/assert-valid.ts
@@ -1,5 +1,5 @@
-import {inspect} from 'util';
 import {Descriptor} from '../descriptor';
+import {inspect} from '../utils';
 import {check, CheckOptions} from './check';
 import {toString} from './to-string';
 
@@ -7,6 +7,6 @@ export function assertValid(d: Descriptor, v: unknown, options?: CheckOptions): 
     const {isValid, errors} = check(d, v, options);
     if (isValid) return;
 
-    let desc = inspect(v, {depth: 0, compact: true, breakLength: Infinity});
+    let desc = inspect(v);
     throw Object.assign(new Error(`${desc} does not conform to type ${toString(d)}`), {errors});
 }

--- a/src/operations/check.ts
+++ b/src/operations/check.ts
@@ -1,6 +1,6 @@
-import {inspect} from 'util';
 import {isValid} from './is-valid';
 import {Descriptor} from '../descriptor';
+import {inspect} from '../utils';
 
 /** Options for checking whether a value confirms to a type. */
 export interface CheckOptions {
@@ -23,7 +23,7 @@ export function check(d: Descriptor, v: unknown, options?: CheckOptions): CheckR
     return errors.length === 0 ? {isValid: true, errors: []} : {isValid: false, errors};
 
     function recurse(d: Descriptor, v: unknown, path: string): void {
-        let desc = inspect(v, {depth: 0, compact: true, breakLength: Infinity});
+        let desc = inspect(v);
         switch (d.kind) {
             case 'any':
                 return;

--- a/src/operations/sanitize.ts
+++ b/src/operations/sanitize.ts
@@ -1,17 +1,18 @@
-import cloneDeep from 'lodash.clonedeep';
 import {Descriptor} from '../descriptor';
 import {isValid} from './is-valid';
 
-// TODO: doc... precond: The runtime value `v` conforms to the type described by `t`.
+// Precondition: `v` must already be known to conform to the type descriptor `d`.
 export function sanitize(d: Descriptor, v: unknown): unknown {
     switch (d.kind) {
 
+        // Arrays/tuples: recursively sanitize only recognised elements into a new array instance.
         case 'array':
         case 'tuple': {
             let ar = v as unknown[];
             return ar.map((el, i) => sanitize(d.kind === 'tuple' ? d.elements[i] : d.element, el));
         }
 
+        // Objects: recursively sanitize only recognised properties into a new object instance.
         case 'object': {
             let obj = v as any;
             let clonedObj = {} as any;
@@ -26,9 +27,9 @@ export function sanitize(d: Descriptor, v: unknown): unknown {
             return clonedObj;
         }
             
+        // Intersections: perform excess property removal against an Object descriptor with the
+        // union of all the properties of intersection members which are Object descriptors.
         case 'intersection': {
-            // Do excess property removal against an Object descriptor with the union
-            // of all the properties of intersection members which are Object descriptors.
             return sanitize({
                 kind: 'object',
                 properties: d.members.reduce(
@@ -38,14 +39,14 @@ export function sanitize(d: Descriptor, v: unknown): unknown {
             }, v);
         }
 
+        // Unions: perform excess property removal against the first union member type that
+        // matches the value `v` (there must be at least one according to preconditions).
         case 'union': {
-            // Find the first union member type that matches the value `v`. There must be one according to preconds.
             let matchingType = d.members.find(m => isValid(m, v))!;
-
-            // Do excess property removal against the matching member type found above.
             return sanitize(matchingType, v);
         }
 
+        // Primitive values: copy the value.
         case 'boolean':
         case 'brandedString':
         case 'null':
@@ -54,12 +55,19 @@ export function sanitize(d: Descriptor, v: unknown): unknown {
         case 'undefined':
         case 'unit':
             return v;
-        
-        case 'any':
+
+        // Supported reference types: Shallow-copy the reference.
         case 'date':
-        case 'never':
+            return v;
+
+        // Any/unknown: Shallow-copy the reference since the type does not retrict the internal structure.
+        case 'any':
         case 'unknown':
-            return cloneDeep(v);
+            return v;
+
+        // Never: This type has no values, so it is an error to reach this code.
+        case 'never':
+            throw new Error(`Precondition violation: sanitize() called on a value that does not conform to the type.`);
 
         default:
             ((type: never) => { throw new Error(`Unhandled type '${type}'`) })(d);

--- a/src/type-info.ts
+++ b/src/type-info.ts
@@ -88,8 +88,12 @@ export type TypeInfo<T = unknown> = {
     isValid(v: unknown, options?: CheckOptions): v is T;
 
     /**
-     * Returns a deep clone of the value `v` containing only properties that are explicitly present in the type.
-     * That is, all excess properties are removed in the returned value.
+     * Given a value `v` that is already known to conform to the type, this method returns a copy of the value
+     * containing only components that are explicitly present in the type. That is, properties and elements in the input
+     * value that are not explicitly present in the type are not copied to the output value.
+     * 
+     * NOTE: the output value is not guaranteed to be a deep clone. For example, values typed as `date`, `any` or
+     * `unknown` are shallow-copied to the output value.
      */
     sanitize(v: T): T;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export {Anonymize} from './anonymize';
+export {inspect} from './inspect';

--- a/src/utils/inspect.ts
+++ b/src/utils/inspect.ts
@@ -1,4 +1,8 @@
 export function inspect(v: unknown): string {
+    return inspectInternal(v, new Set());
+}
+
+function inspectInternal(v: unknown, seen: Set<unknown>): string {
     if (v === null || v === undefined || typeof v === 'number' || typeof v === 'boolean') {
         return String(v);
     }
@@ -11,10 +15,15 @@ export function inspect(v: unknown): string {
         return v.toISOString();
     }
 
+    if (seen.has(v)) {
+        return '[cyclic]';
+    }
+
     if (typeof v === 'object' && !Array.isArray(v)) {
+        seen.add(v);
         const obj = v as Record<string, unknown>;
         const props = Object.keys(obj).map(propName => {
-            const value = inspect(obj[propName]);
+            const value = inspectInternal(obj[propName], seen);
             if (!/^[a-z_$][a-z0-9_$]*$/ig.test(propName)) propName = JSON.stringify(propName);
             return `${propName}: ${value}`;
         });
@@ -22,7 +31,8 @@ export function inspect(v: unknown): string {
     }
 
     if (typeof v === 'object' && Array.isArray(v)) {
-        return `[${v.map(elem => inspect(elem)).join(', ')}]`;
+        seen.add(v);
+        return `[${v.map(elem => inspectInternal(elem, seen)).join(', ')}]`;
     }
 
     return `[${(v as any).constructor.name}]`;

--- a/src/utils/inspect.ts
+++ b/src/utils/inspect.ts
@@ -1,0 +1,29 @@
+export function inspect(v: unknown): string {
+    if (v === null || v === undefined || typeof v === 'number' || typeof v === 'boolean') {
+        return String(v);
+    }
+
+    if (typeof v === 'string') {
+        return JSON.stringify(v);
+    }
+
+    if (v instanceof Date) {
+        return v.toISOString();
+    }
+
+    if (typeof v === 'object' && !Array.isArray(v)) {
+        const obj = v as Record<string, unknown>;
+        const props = Object.keys(obj).map(propName => {
+            const value = inspect(obj[propName]);
+            if (!/^[a-z_$][a-z0-9_$]*$/ig.test(propName)) propName = JSON.stringify(propName);
+            return `${propName}: ${value}`;
+        });
+        return `{${props.join(', ')}}`;
+    }
+
+    if (typeof v === 'object' && Array.isArray(v)) {
+        return `[${v.map(elem => inspect(elem)).join(', ')}]`;
+    }
+
+    return `[${(v as any).constructor.name}]`;
+}

--- a/tests/api-v0/get-validation-errors.test.ts
+++ b/tests/api-v0/get-validation-errors.test.ts
@@ -26,7 +26,7 @@ describe('The getValidationErrors() function', () => {
         {
             type: t.union(t.unit('foo'), t.unit('bar')),
             value: 'baz',
-            expectedErrors: [{path: '^', message: `The value 'baz' does not conform to the union type`}],
+            expectedErrors: [{path: '^', message: `The value "baz" does not conform to the union type`}],
             expectedWarnings: [],
         },
         {
@@ -40,7 +40,7 @@ describe('The getValidationErrors() function', () => {
             value: {foo: {str: true, num: {pi: 3.14}}},
             expectedErrors: [
                 {path: '^.foo.str', message: `Expected a string but got true`},
-                {path: '^.foo.num', message: `Expected a number but got { pi: 3.14 }`}
+                {path: '^.foo.num', message: `Expected a number but got {pi: 3.14}`}
             ],
             expectedWarnings: [],
         },
@@ -48,9 +48,9 @@ describe('The getValidationErrors() function', () => {
             type: t.object({nums: t.array(t.number)}),
             value: {nums: [3.14, -1, NaN, 'one', 42, '3', {zero: true}]},
             expectedErrors: [
-                {path: '^.nums[3]', message: `Expected a number but got 'one'`},
-                {path: '^.nums[5]', message: `Expected a number but got '3'`},
-                {path: '^.nums[6]', message: `Expected a number but got { zero: true }`},
+                {path: '^.nums[3]', message: `Expected a number but got "one"`},
+                {path: '^.nums[5]', message: `Expected a number but got "3"`},
+                {path: '^.nums[6]', message: `Expected a number but got {zero: true}`},
             ],
             expectedWarnings: [],
         },

--- a/tests/assert-valid.test.ts
+++ b/tests/assert-valid.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {t} from 'rtti';
 
-describe('The assertValid() function', () => {
+describe('The assertValid() method', () => {
 
     const values = {
         string: 'kasdjfkjasdfgasjkdhgfkasjdhgf',

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {inspect} from 'util';
 import {t} from 'rtti';
 
-describe('The check() function', () => {
+describe('The check() method', () => {
 
     const tests = [
         {
@@ -26,7 +26,7 @@ describe('The check() function', () => {
         {
             type: t.union(t.unit('foo'), t.unit('bar')),
             value: 'baz',
-            expectedErrors: [{path: '^', message: `The value 'baz' does not conform to the union type`}],
+            expectedErrors: [{path: '^', message: `The value "baz" does not conform to the union type`}],
             expectedStrictErrors: [],
         },
         {
@@ -40,7 +40,7 @@ describe('The check() function', () => {
             value: {foo: {str: true, num: {pi: 3.14}}},
             expectedErrors: [
                 {path: '^.foo.str', message: `Expected a string but got true`},
-                {path: '^.foo.num', message: `Expected a number but got { pi: 3.14 }`}
+                {path: '^.foo.num', message: `Expected a number but got {pi: 3.14}`}
             ],
             expectedStrictErrors: [],
         },
@@ -48,9 +48,9 @@ describe('The check() function', () => {
             type: t.object({nums: t.array(t.number)}),
             value: {nums: [3.14, -1, NaN, 'one', 42, '3', {zero: true}]},
             expectedErrors: [
-                {path: '^.nums[3]', message: `Expected a number but got 'one'`},
-                {path: '^.nums[5]', message: `Expected a number but got '3'`},
-                {path: '^.nums[6]', message: `Expected a number but got { zero: true }`},
+                {path: '^.nums[3]', message: `Expected a number but got "one"`},
+                {path: '^.nums[5]', message: `Expected a number but got "3"`},
+                {path: '^.nums[6]', message: `Expected a number but got {zero: true}`},
             ],
             expectedStrictErrors: [],
         },

--- a/tests/is-valid.test.ts
+++ b/tests/is-valid.test.ts
@@ -3,7 +3,7 @@ import {t} from 'rtti';
 
 // TODO: test with allowExcessProperties: false
 
-describe('The isValid() function', () => {
+describe('The isValid() method', () => {
 
     const values = {
         string: 'kasdjfkjasdfgasjkdhgfkasjdhgf',

--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {inspect} from 'util';
 import {t} from 'rtti';
 
-describe('The removeExcessProperties() function', () => {
+describe('The sanitize() method', () => {
 
     const tests = [
         {

--- a/tests/to-json-schema.test.ts
+++ b/tests/to-json-schema.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {t, TypeInfo} from 'rtti';
 
-describe('The toJsonSchema() function', () => {
+describe('The toJsonSchema() method', () => {
     const testCases: Array<{type: TypeInfo, jsonSchema: unknown}> = [
         {
             type: t.string,

--- a/tests/to-string.test.ts
+++ b/tests/to-string.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {t} from 'rtti';
 
-describe('The toString() function', () => {
+describe('The toString() method', () => {
 
     const tests = [
         {


### PR DESCRIPTION
Removed usages of `inspect` (from node's 'util' module), and `cloneDeep` from lodash. This means the package no longer has any external runtime dependencies.

Treating as a patch version change, since the only observable changes are not subject to any specified guarantees in the API. The observable changes are (a) precise formatting of validation messages and (b) precise cloning behaviour of `sanitize`.

NOTE: there are still some devDeps for building/testing the package.

Fixes #18 
