### PR TITLE
Fix type inference for optional properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "rtti",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "rtti",
-            "version": "1.1.1",
+            "version": "1.1.4",
             "license": "MIT",
             "devDependencies": {
                 "@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rtti",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Runtime type validation for JavaScript and TypeScript programs",
     "main": "dist/commonjs/index.js",
     "typings": "dist/commonjs/index.d.ts",

--- a/src/create-type-info.ts
+++ b/src/create-type-info.ts
@@ -1,4 +1,4 @@
-import type {Descriptor, Optional} from './descriptor';
+import type {Descriptor} from './descriptor';
 import * as op from './operations';
 import type {TypeInfo} from './type-info'; // NB: type-only import (no cyclic imports at runtime)
 import type {Anonymize} from './utils';
@@ -74,7 +74,7 @@ type TypeOfUnion<Members> = Members[any] extends infer E ? (E extends TypeInfo<i
 
 type TypeOfObject<Props> = Anonymize<
     & {[K in RequiredPropNames<Props>]: Props[K] extends TypeInfo<infer T> ? T : 0}
-    & {[K in OptionalPropNames<Props>]?: Props[K] extends Optional<TypeInfo<infer T>> ? T : 0}
+    & {[K in OptionalPropNames<Props>]?: Props[K] extends {kind: 'optional', type: TypeInfo<infer T>} ? T : 0}
 >;
-type RequiredPropNames<Props> = {[K in keyof Props]: Props[K] extends Optional ? never : K}[keyof Props];
-type OptionalPropNames<Props> = {[K in keyof Props]: Props[K] extends Optional ? K : never}[keyof Props];
+type RequiredPropNames<Props> = {[K in keyof Props]: Props[K] extends {kind: 'optional'} ? never : K}[keyof Props];
+type OptionalPropNames<Props> = {[K in keyof Props]: Props[K] extends {kind: 'optional'} ? K : never}[keyof Props];

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,7 +1,8 @@
 // Type tests: the code here is not executed, it just needs to pass type checks to be considered successful.
-// Added as regression test for bug caused by https://github.com/microsoft/TypeScript/issues/46655.
-// Note that `t` is imported from the built declaration files, since that's where the regression occurred.
 
+// --------------------------------------------------
+// Regression test for bug caused by https://github.com/microsoft/TypeScript/issues/46655.
+// Note that `t` is imported from the built declaration files, since that's where the regression occurred.
 import {t} from '../dist/commonjs';
 export {test1, test2};
 
@@ -32,3 +33,13 @@ function test2(t2: typeof T2.example) {
         default: ((x: never) => x)(t2);
     }
 }
+
+// --------------------------------------------------
+// Regression test for https://github.com/yortus/http-schemas/issues/30
+const Result = t.object({
+    date: t.string,
+    foobar: t.optional(t.number),
+});
+type Result = typeof Result.example;
+let result: Result = {date: '1234'};
+if (result.foobar) result.foobar.toExponential;


### PR DESCRIPTION
This PR fixes the regression in type inference for optional properties that was reported in https://github.com/yortus/http-schemas/issues/30.

